### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,30 @@
 MIT License
 
+Copyright (c) 2024 kanazawazawa
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+(This repository was created by duplicating the repository at the following URL. The original license is listed below.)
+https://github.com/tenjoufire/ghcbws
+
+MIT License
+
 Copyright (c) 2024 tenjoufire
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
This pull request includes an update to the `LICENSE` file to reflect the new copyright holder and provide additional context about the repository.

Changes in `LICENSE`:

* Added a new copyright notice for "kanazawazawa" for the year 2024. (F07b866cL1)
* Included a statement that the repository was created by duplicating another repository, with a reference to the original URL. (F07b866cL1)
* Added the full text of the MIT License for the new copyright holder. (F07b866cL1)